### PR TITLE
Refactor generate-proto.yml workflow to remove auto versioning and co…

### DIFF
--- a/.github/workflows/generate-proto.yml
+++ b/.github/workflows/generate-proto.yml
@@ -33,8 +33,14 @@ jobs:
 
       - name: Auto Versioning (Tagging)
         run: |
-          # Try to get the latest tag, default to 0.0.0 if none exists
+          # Fetch all tags from the remote
+          git fetch --tags
+
+          # Try to get the latest tag, default to v0.0.0 if none exists
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
+          # Remove the 'v' prefix from the version
+          CURRENT_VERSION=${CURRENT_VERSION#v}
 
           # Split the version into its components
           IFS='.' read -r -a VERSION_PARTS <<< "$CURRENT_VERSION"
@@ -43,7 +49,7 @@ jobs:
           VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
 
           # Construct the new version
-          NEW_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+          NEW_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
 
           # Create the new tag
           git tag "$NEW_VERSION"


### PR DESCRIPTION
This pull request includes changes to the auto versioning and tagging process in the GitHub workflow configuration file. The most important changes involve fetching all tags from the remote repository, handling version strings more robustly, and ensuring the correct format for new version tags.

Improvements to auto versioning and tagging:

* [`.github/workflows/generate-proto.yml`](diffhunk://#diff-60b02be9b9d543e9415fb8cbf9c9840f6675311ed9f143bcbba45e89bd220dd6L36-R52): Added a step to fetch all tags from the remote repository to ensure the latest tags are available locally.
* [`.github/workflows/generate-proto.yml`](diffhunk://#diff-60b02be9b9d543e9415fb8cbf9c9840f6675311ed9f143bcbba45e89bd220dd6L36-R52): Modified the script to handle version strings by removing the 'v' prefix from the current version and ensuring the new version tag includes the 'v' prefix.